### PR TITLE
Handle transaction numbers

### DIFF
--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -80,6 +80,9 @@ exports.parse = function(qif) {
                 division = {};
 
                 break;
+            case 'N':
+                transaction.number = line.substring(1);
+                break;
 
             default:
                 throw new Error('Unknown Detail Code: ' + line[0]);


### PR DESCRIPTION
I have a qif file which contains 'N' type lines which contain details about the transaction number (typically a cheque/check number.  The change here captures that tag rather than throwing an error.