### PR TITLE
Older QIF files cross the millennium with 2 digit dates

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,6 +3,8 @@
 var qif2json = require('./lib/qif2json.js'),
     args = process.argv.slice(2),
     transactionsOnly,
+    usDates,
+    oldDates,
     file;
 
 args.forEach(function(arg) {
@@ -14,6 +16,12 @@ args.forEach(function(arg) {
         case '--transactions':
         case '-t':
             transactionsOnly = true;
+            break;
+        case '-u':
+            usDates = true;
+            break;
+        case '-m':
+            oldDates = true;
             break;
     }
 });
@@ -31,9 +39,11 @@ function output(err, data) {
     console.log(JSON.stringify(data, null, 4));
 }
 
+var options = {usDates, oldDates};
+
 if (!file) {
-    qif2json.parseStream(process.stdin, output);
+    qif2json.parseStream(process.stdin, options, output);
     process.stdin.resume();
 } else {
-    qif2json.parseFile(file, output);
+    qif2json.parseFile(file, options, output);
 }

--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -10,8 +10,9 @@ var fs = require('fs'),
     jschardet = require('jschardet'),
     Iconv = require('iconv').Iconv;
 
-function parseDate(str, format) {
-    var date = str.replace(' ', '').split(/[^0-9]/);
+function parseDate(str, usDates, mixed) {
+    // sometimes in the 2000's there are multiple spaces
+    var date = str.replace(/ /g, '').split(/[^0-9]/);
 
     if (date[0].length < 2) {
         date[0] = '0' + date[0];
@@ -20,14 +21,31 @@ function parseDate(str, format) {
         date[1] = '0' + date[1];
     }
     if (date[2].length <= 2) {
-        date[2] = 2000 + parseInt(date[2], 10);
-
-        if (date[2] > new Date().getFullYear()) {
-            date[2] -= 100;
+        var century = 1900;
+        var twoDigit = parseInt(date[2], 10);
+        if (mixed) {
+            // Hey a real Y2K problem solution in the wild!
+            // On older versions of QIF exports with data from the 90s
+            // When mixed dates are present, QB uses ' instead of /
+            // the ' indicates the millenium
+            // Dec 31, 1999: "D12/31/99"
+            // Jan 1, 2000:  "D 1/ 1' 0"
+            if (str.indexOf("'") > -1) {
+                century = 2000;
+            }
         }
+        else {
+            if (twoDigit < 83) { 
+                // quicken released in 1983!
+                // This compare is faster than new Date()
+                // Will work OK until 2083, almost 64 years.           
+                century = 2000;
+            }
+        }
+        date[2] = century + twoDigit;
     }
 
-    if (format === 'us') {
+    if (usDates) {
         return date[2] + '-' + date[0] + '-' + date[1];
     }
     return date[2] + '-' + date[1] + '-' + date[0];
@@ -42,6 +60,10 @@ exports.parse = function(qif, options) {
         transaction = {};
 
     options = options || {};
+    if(options.dateFormat){
+      // no need to break old code. There was only one option previously
+      options.usDates = true;
+    }
 
     if (!type || !type.length) {
         throw new Error('File does not appear to be a valid qif file: ' + line);
@@ -59,7 +81,10 @@ exports.parse = function(qif, options) {
         }
         switch (line[0]) {
             case 'D':
-                transaction.date = parseDate(line.substring(1), options.dateFormat);
+                transaction.date = parseDate(line.substring(1), options.usDates, options.oldDates);
+                break;
+            case 'U':
+                // Looks like a legacy repeat of 'T'
                 break;
             case 'T':
                 transaction.amount = parseFloat(line.substring(1).replace(',', ''));

--- a/test/qif2json.tests.js
+++ b/test/qif2json.tests.js
@@ -77,11 +77,11 @@ describe('qif2json', function() {
         var err, data;
         try {
             data = qif2json.parse(['!Type:Bank',
-'123',
-'^',
-''].join('\r\n'));
+              '123',
+              '^',
+              ''].join('\r\n'));
         } catch (e) {
-            err = e;
+           err = e;
         }
 
         expect(err).toBeDefined();
@@ -191,6 +191,22 @@ describe('qif2json', function() {
         expect(data.transactions[0].amount).toEqual(1);
         expect(data.transactions[0].payee).toEqual('Opening Balance');
     });
+
+    it ('can parse mixed millenium dates', function() {
+        var data = qif2json.parse(['!Type:Bank',
+            'D11/10/99',
+            'T1',
+            'POpening Balance',
+            '^',
+            "D3/ 1' 0",
+            'T-1',
+            'PCITY OF SPRINGFIELD\r\n'].join('\r\n'), {dateFormat: 'us', oldDates: true});
+
+        expect(data.type).toEqual('Bank');
+        expect(data.transactions[0].date).toEqual('1999-11-10');
+        expect(data.transactions[1].date).toEqual('2000-03-01');
+    });
+
 
     it ('can parse descriptions in partial transaction', function() {
         var data = qif2json.parse(['!Type:Cardname',


### PR DESCRIPTION
1. Mixed Dates
  In some systems, the millenium is marked with a single quote that can be detected:3/ 1' 0
  Sometimes dates have several spaces that weren't getting correctly picked up by the string replace(' ','') call, this was updated to use / /g instead
2. Performance
  Checking for these where possible or comparing to the creation of quicken is slightly faster. 
  Modern CPU takes 30 seconds for 6K transactions
3. Command line options
  -u for us month/day flipping
  -m for dates mixed across the millenium
4. Tests
  test case added for date supported here in this PR.  Old tests are unchanged to avoid any breakage