### PR TITLE
Switching to iconv-lite

### DIFF
--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -9,7 +9,7 @@
 
 const fs = require('fs');
 const jschardet = require('jschardet');
-const { Iconv } = require('iconv');
+const Iconv = require('iconv-lite');
 
 function parseDate(str, format) {
   const date = str.replace(' ', '').split(/[^0-9]/);
@@ -123,7 +123,6 @@ exports.parse = function parse(qif, options) {
 
 exports.parseInput = function paeeInput(qifData, options, callback) {
   const { encoding } = jschardet.detect(qifData);
-  let iconv;
   let err;
 
   if (!callback) {
@@ -132,8 +131,7 @@ exports.parseInput = function paeeInput(qifData, options, callback) {
   }
 
   if (encoding.toUpperCase() !== 'UTF-8' && encoding.toUpperCase() !== 'ASCII') {
-    iconv = new Iconv(encoding, 'UTF-8');
-    qifData = iconv.convert(qifData).toString();
+    qifData = Iconv.decode(qifData, encoding);
   } else {
     qifData = qifData.toString('utf8');
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1284,20 +1284,10 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
-    "iconv": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/iconv/-/iconv-2.3.2.tgz",
-      "integrity": "sha512-BDZ6vxEFhU6oWrtKEsEREMrxjDn2FccWHVMicUrgq3Ngij9jvh/jsP90K1UbMIavagkJ7EOagr+cJh8P9Jq5Qw==",
-      "requires": {
-        "nan": "^2.11.1",
-        "safer-buffer": "^2.1.2"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -1835,11 +1825,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "iconv": "^2.3.2",
+    "iconv-lite": "^0.4.24",
     "jschardet": "^2.1.0"
   }
 }


### PR DESCRIPTION
Thanks for creating a useful utility to parse `qif` statements. I integrated it into my project and it works a treat. However, when building a docker image for it based on node-alpine, the iconv library causes issues as it needs to be built from source.

By switching to `iconv-lite` and adjusting the code slightly, you get easier build and better performance. All the unit tests have passed with my changes.