### PR TITLE
Date formatting options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,6 @@ module.exports = {
     ecmaVersion: 2018,
   },
   rules: {
+    'no-continue': 'off'
   },
 };

--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@ Install the module with: `npm install qif2json`
 
 ```javascript
 var qif2json = require('qif2json');
-qif2json.parse(qifData);
+qif2json.parse(qifData, options);
 
 // Or to read in a file directly
-qif2json.parseFile(filePath, function(err, qifData){
+qif2json.parseFile(filePath, options, function(err, qifData){
     // done!
 });
 ```
 
 If installed globally, the `qif2json` command can also be used with an input file and the output JSON will be pretty-printed to the console
+
+## Options
+
+* `dateFormat` - The format of dates within the file.  The `fetcha` module is used for parsing them into Date objects.  See https://www.npmjs.com/package/fecha#formatting-tokens for available formatting tokens. The special format `"us"` will use us-format MM/DD/YYYY dates. Dates are normalised before parsing so `/`, `'` become `-` and spaces are removed.
 
 ## Contributing
 Take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using `npm test`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If installed globally, the `qif2json` command can also be used with an input fil
 
 ## Options
 
-* `dateFormat` - The format of dates within the file.  The `fetcha` module is used for parsing them into Date objects.  See https://www.npmjs.com/package/fecha#formatting-tokens for available formatting tokens. The special format `"us"` will use us-format MM/DD/YYYY dates. Dates are normalised before parsing so `/`, `'` become `-` and spaces are removed.
+* `dateFormat` - The format of dates within the file.  The `fetcha` module is used for parsing them into Date objects.  See https://www.npmjs.com/package/fecha#formatting-tokens for available formatting tokens. The special format `"us"` will use us-format MM/DD/YYYY dates. Dates are normalised before parsing so `/`, `'` become `-` and spaces are removed.  On the commandline you can specify multiple date formats comma-delimited.
 
 ## Contributing
 Take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using `npm test`.

--- a/cli.js
+++ b/cli.js
@@ -20,7 +20,7 @@ while (args.length > 0) {
       break;
     case '--date-format':
     case '-d':
-      dateFormat = args.shift();
+      dateFormat = args.shift().split(',');
       break;
     default:
       break;

--- a/cli.js
+++ b/cli.js
@@ -5,21 +5,27 @@ const qif2json = require('./lib/qif2json.js');
 const args = process.argv.slice(2);
 let transactionsOnly;
 let file;
+let dateFormat;
 
-args.forEach((arg) => {
+while (args.length > 0) {
+  const arg = args.shift();
   if (arg.indexOf('-') !== 0) {
     file = arg;
-    return;
+    continue;
   }
   switch (arg) {
     case '--transactions':
     case '-t':
       transactionsOnly = true;
       break;
+    case '--date-format':
+    case '-d':
+      dateFormat = args.shift();
+      break;
     default:
       break;
   }
-});
+}
 
 function output(err, data) {
   let finalData = data;
@@ -36,8 +42,8 @@ function output(err, data) {
 }
 
 if (!file) {
-  qif2json.parseStream(process.stdin, output);
+  qif2json.parseStream(process.stdin, { dateFormat }, output);
   process.stdin.resume();
 } else {
-  qif2json.parseFile(file, output);
+  qif2json.parseFile(file, { dateFormat }, output);
 }

--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -121,7 +121,7 @@ exports.parse = function parse(qif, options) {
   return data;
 };
 
-exports.parseInput = function paeeInput(qifData, options, callback) {
+exports.parseInput = function parseInput(qifData, options, callback) {
   const { encoding } = jschardet.detect(qifData);
   let err;
 
@@ -131,7 +131,7 @@ exports.parseInput = function paeeInput(qifData, options, callback) {
   }
 
   if (encoding.toUpperCase() !== 'UTF-8' && encoding.toUpperCase() !== 'ASCII') {
-    qifData = Iconv.decode(qifData, encoding);
+    qifData = Iconv.decode(Buffer.from(qifData), encoding);
   } else {
     qifData = qifData.toString('utf8');
   }

--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -12,26 +12,29 @@ const jschardet = require('jschardet');
 const Iconv = require('iconv-lite');
 const fecha = require('fecha');
 
-const US_DATE_FORMAT = 'MM-DD-YY';
-const UK_DATE_FORMAT = 'DD-MM-YY';
+const US_DATE_FORMATS = ['MM-DD-YYYYHH:mm:ss', 'MM-DD-YYYY', 'MM-DD-YY'];
+const UK_DATE_FORMATS = ['DD-MM-YYYYHH:mm:ss', 'DD-MM-YYYY', 'DD-MM-YY'];
 
-function parseDate(dateStr, format) {
-  if (format === 'us') {
-    format = US_DATE_FORMAT;
+function parseDate(dateStr, formats) {
+  if (formats === 'us') {
+    formats = US_DATE_FORMATS;
   }
-  if (!format) {
-    format = UK_DATE_FORMAT;
+  if (!formats) {
+    formats = UK_DATE_FORMATS;
   }
+  formats = [].concat(formats);
 
   let str = dateStr.replace(/ /g, '');
   str = str.replace(/\//g, '-');
   str = str.replace(/'/g, '-');
   str = str.replace(/(^|[^0-9])([0-9])([^0-9]|$)/, '$10$2$3');
 
-  const formatted = fecha.parse(str, format);
+  while (formats.length) {
+    const formatted = fecha.parse(str, formats.shift());
 
-  if (formatted) {
-    return fecha.format(formatted, 'YYYY-MM-DD');
+    if (formatted) {
+      return fecha.format(formatted, 'YYYY-MM-DD');
+    }
   }
 
   return `<invalid date:"${dateStr}">`;

--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -10,28 +10,31 @@
 const fs = require('fs');
 const jschardet = require('jschardet');
 const Iconv = require('iconv-lite');
+const fecha = require('fecha');
 
-function parseDate(str, format) {
-  const date = str.replace(' ', '').split(/[^0-9]/);
+const US_DATE_FORMAT = 'MM-DD-YY';
+const UK_DATE_FORMAT = 'DD-MM-YY';
 
-  if (date[0].length < 2) {
-    date[0] = `0${date[0]}`;
-  }
-  if (date[1].length < 2) {
-    date[1] = `0${date[1]}`;
-  }
-  if (date[2].length <= 2) {
-    date[2] = 2000 + parseInt(date[2], 10);
-
-    if (date[2] > new Date().getFullYear()) {
-      date[2] -= 100;
-    }
-  }
-
+function parseDate(dateStr, format) {
   if (format === 'us') {
-    return `${date[2]}-${date[0]}-${date[1]}`;
+    format = US_DATE_FORMAT;
   }
-  return `${date[2]}-${date[1]}-${date[0]}`;
+  if (!format) {
+    format = UK_DATE_FORMAT;
+  }
+
+  let str = dateStr.replace(/ /g, '');
+  str = str.replace(/\//g, '-');
+  str = str.replace(/'/g, '-');
+  str = str.replace(/(^|[^0-9])([0-9])([^0-9]|$)/, '$10$2$3');
+
+  const formatted = fecha.parse(str, format);
+
+  if (formatted) {
+    return fecha.format(formatted, 'YYYY-MM-DD');
+  }
+
+  return `<invalid date:"${dateStr}">`;
 }
 
 exports.parse = function parse(qif, options) {

--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -33,7 +33,7 @@ function parseDate(dateStr, formats) {
     const formatted = fecha.parse(str, formats.shift());
 
     if (formatted) {
-      return fecha.format(formatted, 'YYYY-MM-DD');
+      return fecha.format(formatted, 'YYYY-MM-DDTHH:mm:ss');
     }
   }
 

--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const jschardet = require('jschardet');
 const Iconv = require('iconv-lite');
 const fecha = require('fecha');
+const debug = require('debug')('qif2json');
 
 const US_DATE_FORMATS = ['MM-DD-YYYYHH:mm:ss', 'MM-DD-YYYY', 'MM-DD-YY'];
 const UK_DATE_FORMATS = ['DD-MM-YYYYHH:mm:ss', 'DD-MM-YYYY', 'DD-MM-YY'];
@@ -28,11 +29,14 @@ function parseDate(dateStr, formats) {
   str = str.replace(/\//g, '-');
   str = str.replace(/'/g, '-');
   str = str.replace(/(^|[^0-9])([0-9])([^0-9]|$)/g, '$10$2$3');
+  debug(`input date ${dateStr} became ${str}`);
 
   while (formats.length) {
-    const formatted = fecha.parse(str, formats.shift());
+    const format = formats.shift();
+    const formatted = fecha.parse(str, format);
 
     if (formatted) {
+      debug(`input date ${str} parses correctly with ${format}`);
       return fecha.format(formatted, 'YYYY-MM-DDTHH:mm:ss');
     }
   }

--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -73,6 +73,9 @@ exports.parse = function parse(qif, options) {
       case 'T':
         transaction.amount = parseFloat(line.substring(1).replace(',', ''));
         break;
+      case 'U':
+        // Looks like a legacy repeat of 'T'
+        break;
       case 'N':
         transaction.number = line.substring(1);
         break;

--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -27,7 +27,7 @@ function parseDate(dateStr, formats) {
   let str = dateStr.replace(/ /g, '');
   str = str.replace(/\//g, '-');
   str = str.replace(/'/g, '-');
-  str = str.replace(/(^|[^0-9])([0-9])([^0-9]|$)/, '$10$2$3');
+  str = str.replace(/(^|[^0-9])([0-9])([^0-9]|$)/g, '$10$2$3');
 
   while (formats.length) {
     const formatted = fecha.parse(str, formats.shift());

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,10 +235,9 @@
       }
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1155,13 +1154,23 @@
         "yargs": "13.2.2",
         "yargs-parser": "13.0.0",
         "yargs-unparser": "1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -625,6 +625,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fecha": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-3.0.3.tgz",
+      "integrity": "sha512-6LQK/1jud/FZnfEEZJ7y81vw7ge81DNd/XEsX0hgMUjhS+QMljkb1C0czBaP7dMNRVrd5mw/J2J7qI2Nw+TWZw=="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "keywords": [],
   "dependencies": {
+    "fecha": "^3.0.3",
     "iconv-lite": "^0.4.24",
     "jschardet": "^2.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "keywords": [],
   "dependencies": {
+    "debug": "^4.1.1",
     "fecha": "^3.0.3",
     "iconv-lite": "^0.4.24",
     "jschardet": "^2.1.0"

--- a/test/normalTransactions.tests.js
+++ b/test/normalTransactions.tests.js
@@ -11,7 +11,7 @@ describe('normalTransactions', () => {
 
       expect(qifData.type).toEqual('Bank');
       expect(qifData.transactions.length).toEqual(3);
-      expect(qifData.transactions[0].date).toEqual('1994-06-01');
+      expect(qifData.transactions[0].date).toEqual('1994-06-01T00:00:00');
       expect(qifData.transactions[0].amount).toEqual(-1000);
       expect(qifData.transactions[0].number).toEqual('1005');
       expect(qifData.transactions[0].payee).toEqual('Bank Of Mortgage');
@@ -22,11 +22,11 @@ describe('normalTransactions', () => {
       expect(qifData.transactions[0].division[1].category).toEqual('Mort Int');
       expect(qifData.transactions[0].division[1].amount).toEqual(-746.36);
 
-      expect(qifData.transactions[1].date).toEqual('1994-06-02');
+      expect(qifData.transactions[1].date).toEqual('1994-06-02T00:00:00');
       expect(qifData.transactions[1].amount).toEqual(75);
       expect(qifData.transactions[1].payee).toEqual('Deposit');
 
-      expect(qifData.transactions[2].date).toEqual('1994-06-03');
+      expect(qifData.transactions[2].date).toEqual('1994-06-03T00:00:00');
       expect(qifData.transactions[2].amount).toEqual(-10);
       expect(qifData.transactions[2].payee).toEqual('JoBob Biggs');
       expect(qifData.transactions[2].memo).toEqual('J.B. gets bucks');

--- a/test/qif2json.tests.js
+++ b/test/qif2json.tests.js
@@ -219,4 +219,28 @@ describe('qif2json', () => {
     expect(data.transactions[0].division[2].amount).toEqual(-6);
     expect(data.transactions[0].division[1].description).toEqual('Pork belly');
   });
+
+  it('Can parse timestamp example', () => {
+    const data = qif2json.parse(['!Type:Bank',
+      'D26-06-2019 00:00:00',
+      'T-379.00',
+      'PCITY OF SPRINGFIELD',
+      '^',
+      'D27-06-2019 00:00:00',
+      'T-20.28',
+      'PYOUR LOCAL SUPERMARKET',
+      '^',
+      'D28-06-2019 00:00:00',
+      'T-421.35',
+      'PSPRINGFIELD WATER UTILITY',
+      '^',
+    ].join('\r\n'));
+
+    expect(data.type).toEqual('Bank');
+    expect(data.transactions.length).toEqual(3);
+
+    expect(data.transactions[0].date).toEqual('2019-06-26');
+    expect(data.transactions[0].amount).toEqual(-379);
+    expect(data.transactions[0].payee).toEqual('CITY OF SPRINGFIELD');
+  });
 });

--- a/test/qif2json.tests.js
+++ b/test/qif2json.tests.js
@@ -244,6 +244,21 @@ describe('qif2json', () => {
     expect(data.transactions[0].payee).toEqual('CITY OF SPRINGFIELD');
   });
 
+  it('can parse mixed millenium dates', () => {
+    const data = qif2json.parse(['!Type:Bank',
+      'D11/10/99',
+      'T1',
+      'POpening Balance',
+      '^',
+      "D3/ 1' 0",
+      'T-1',
+      'PCITY OF SPRINGFIELD\r\n'].join('\r\n'), { dateFormat: 'us' });
+
+    expect(data.type).toEqual('Bank');
+    expect(data.transactions[0].date).toEqual('1999-11-10T00:00:00');
+    expect(data.transactions[1].date).toEqual('2000-03-01T00:00:00');
+  });
+
   it('ignores repeated T column instead of crashing on U', () => {
     const data = qif2json.parse(['!Type:Bank',
       'D11/10/99',

--- a/test/qif2json.tests.js
+++ b/test/qif2json.tests.js
@@ -243,4 +243,15 @@ describe('qif2json', () => {
     expect(data.transactions[0].amount).toEqual(-379);
     expect(data.transactions[0].payee).toEqual('CITY OF SPRINGFIELD');
   });
+
+  it('ignores repeated T column instead of crashing on U', () => {
+    const data = qif2json.parse(['!Type:Bank',
+      'D11/10/99',
+      'U1',
+      'T1',
+      'POpening Balance'].join('\r\n'), { dateFormat: 'us' });
+
+    expect(data.type).toEqual('Bank');
+    expect(data.transactions[0].amount).toEqual(1);
+  });
 });

--- a/test/qif2json.tests.js
+++ b/test/qif2json.tests.js
@@ -123,11 +123,11 @@ describe('qif2json', () => {
       'T1,337.00',
       'CX',
       'POpening Balance',
-      'L[AccountName]'].join('\r\n'));
+      'L[AccountName]'].join('\r\n'), { dateFormat: 'us' });
 
     expect(data.type).toEqual('AccounType');
     expect(data.transactions[0].category).toEqual('[AccountName]');
-    expect(data.transactions[0].date).toEqual('2014-26-10');
+    expect(data.transactions[0].date).toEqual('2014-10-26');
     expect(data.transactions[0].amount).toEqual(1337.00);
     expect(data.transactions[0].clearedStatus).toEqual('X');
   });
@@ -143,12 +143,12 @@ describe('qif2json', () => {
       'SFood:Meat',
       '$-16.00',
       'SFood:Dispensary',
-      '$-6.00\r\n'].join('\r\n'));
+      '$-6.00\r\n'].join('\r\n'), { dateFormat: 'us' });
 
     expect(data.type).toEqual('Cardname');
     expect(data.transactions.length).toEqual(1);
 
-    expect(data.transactions[0].date).toEqual('2014-28-10');
+    expect(data.transactions[0].date).toEqual('2014-10-28');
     expect(data.transactions[0].amount).toEqual(-67);
     expect(data.transactions[0].payee).toEqual('Wallmart');
 
@@ -205,12 +205,12 @@ describe('qif2json', () => {
       'EPork belly',
       '$-16.00',
       'SFood:Dispensary',
-      '$-6.00\r\n'].join('\r\n'));
+      '$-6.00\r\n'].join('\r\n'), { dateFormat: 'us' });
 
     expect(data.type).toEqual('Cardname');
     expect(data.transactions.length).toEqual(1);
 
-    expect(data.transactions[0].date).toEqual('2014-28-10');
+    expect(data.transactions[0].date).toEqual('2014-10-28');
     expect(data.transactions[0].amount).toEqual(-67);
     expect(data.transactions[0].payee).toEqual('Wallmart');
 

--- a/test/qif2json.tests.js
+++ b/test/qif2json.tests.js
@@ -21,15 +21,15 @@ describe('qif2json', () => {
     expect(data.type).toEqual('Bank');
     expect(data.transactions.length).toEqual(3);
 
-    expect(data.transactions[0].date).toEqual('2010-03-03');
+    expect(data.transactions[0].date).toEqual('2010-03-03T00:00:00');
     expect(data.transactions[0].amount).toEqual(-379);
     expect(data.transactions[0].payee).toEqual('CITY OF SPRINGFIELD');
 
-    expect(data.transactions[1].date).toEqual('2010-04-03');
+    expect(data.transactions[1].date).toEqual('2010-04-03T00:00:00');
     expect(data.transactions[1].amount).toEqual(-20.28);
     expect(data.transactions[1].payee).toEqual('YOUR LOCAL SUPERMARKET');
 
-    expect(data.transactions[2].date).toEqual('2010-03-03');
+    expect(data.transactions[2].date).toEqual('2010-03-03T00:00:00');
     expect(data.transactions[2].amount).toEqual(-421.35);
     expect(data.transactions[2].payee).toEqual('SPRINGFIELD WATER UTILITY');
   });
@@ -43,7 +43,7 @@ describe('qif2json', () => {
     expect(data.type).toEqual('Bank');
     expect(data.transactions.length).toEqual(1);
 
-    expect(data.transactions[0].date).toEqual('2010-03-03');
+    expect(data.transactions[0].date).toEqual('2010-03-03T00:00:00');
     expect(data.transactions[0].amount).toEqual(-379);
     expect(data.transactions[0].payee).toEqual('CITY OF SPRINGFIELD');
   });
@@ -57,7 +57,7 @@ describe('qif2json', () => {
     expect(data.type).toEqual('Bank');
     expect(data.transactions.length).toEqual(1);
 
-    expect(data.transactions[0].date).toEqual('2010-03-03');
+    expect(data.transactions[0].date).toEqual('2010-03-03T00:00:00');
     expect(data.transactions[0].amount).toEqual(-379);
     expect(data.transactions[0].payee).toEqual('CITY OF SPRINGFIELD');
   });
@@ -127,7 +127,7 @@ describe('qif2json', () => {
 
     expect(data.type).toEqual('AccounType');
     expect(data.transactions[0].category).toEqual('[AccountName]');
-    expect(data.transactions[0].date).toEqual('2014-10-26');
+    expect(data.transactions[0].date).toEqual('2014-10-26T00:00:00');
     expect(data.transactions[0].amount).toEqual(1337.00);
     expect(data.transactions[0].clearedStatus).toEqual('X');
   });
@@ -148,7 +148,7 @@ describe('qif2json', () => {
     expect(data.type).toEqual('Cardname');
     expect(data.transactions.length).toEqual(1);
 
-    expect(data.transactions[0].date).toEqual('2014-10-28');
+    expect(data.transactions[0].date).toEqual('2014-10-28T00:00:00');
     expect(data.transactions[0].amount).toEqual(-67);
     expect(data.transactions[0].payee).toEqual('Wallmart');
 
@@ -164,7 +164,7 @@ describe('qif2json', () => {
       'POpening Balance'].join('\r\n'), { dateFormat: 'us' });
 
     expect(data.type).toEqual('Bank');
-    expect(data.transactions[0].date).toEqual('2016-10-09');
+    expect(data.transactions[0].date).toEqual('2016-10-09T00:00:00');
     expect(data.transactions[0].amount).toEqual(1);
     expect(data.transactions[0].payee).toEqual('Opening Balance');
   });
@@ -176,7 +176,7 @@ describe('qif2json', () => {
       'POpening Balance'].join('\r\n'), { dateFormat: 'us' });
 
     expect(data.type).toEqual('Bank');
-    expect(data.transactions[0].date).toEqual('2009-11-10');
+    expect(data.transactions[0].date).toEqual('2009-11-10T00:00:00');
     expect(data.transactions[0].amount).toEqual(1);
     expect(data.transactions[0].payee).toEqual('Opening Balance');
   });
@@ -188,7 +188,7 @@ describe('qif2json', () => {
       'POpening Balance'].join('\r\n'), { dateFormat: 'us' });
 
     expect(data.type).toEqual('Bank');
-    expect(data.transactions[0].date).toEqual('1999-11-10');
+    expect(data.transactions[0].date).toEqual('1999-11-10T00:00:00');
     expect(data.transactions[0].amount).toEqual(1);
     expect(data.transactions[0].payee).toEqual('Opening Balance');
   });
@@ -210,7 +210,7 @@ describe('qif2json', () => {
     expect(data.type).toEqual('Cardname');
     expect(data.transactions.length).toEqual(1);
 
-    expect(data.transactions[0].date).toEqual('2014-10-28');
+    expect(data.transactions[0].date).toEqual('2014-10-28T00:00:00');
     expect(data.transactions[0].amount).toEqual(-67);
     expect(data.transactions[0].payee).toEqual('Wallmart');
 
@@ -239,7 +239,7 @@ describe('qif2json', () => {
     expect(data.type).toEqual('Bank');
     expect(data.transactions.length).toEqual(3);
 
-    expect(data.transactions[0].date).toEqual('2019-06-26');
+    expect(data.transactions[0].date).toEqual('2019-06-26T00:00:00');
     expect(data.transactions[0].amount).toEqual(-379);
     expect(data.transactions[0].payee).toEqual('CITY OF SPRINGFIELD');
   });


### PR DESCRIPTION
This adds a `dateFormat` option that allows arbitrary date formats to be parsed.  It adds backward compatibility for the old `us` date format

All in all, this deals with #12 and #24 in a unified way (tests and other minor changes copied from those PRs)