### PR TITLE
fix: values more than one million

### DIFF
--- a/lib/qif2json.js
+++ b/lib/qif2json.js
@@ -75,7 +75,7 @@ exports.parse = function parse(qif, options) {
         transaction.date = parseDate(line.substring(1), options.dateFormat);
         break;
       case 'T':
-        transaction.amount = parseFloat(line.substring(1).replace(',', ''));
+        transaction.amount = parseFloat(line.substring(1).replace(/,/g, ''));
         break;
       case 'U':
         // Looks like a legacy repeat of 'T'

--- a/test/qif2json.tests.js
+++ b/test/qif2json.tests.js
@@ -269,4 +269,21 @@ describe('qif2json', () => {
     expect(data.type).toEqual('Bank');
     expect(data.transactions[0].amount).toEqual(1);
   });
+
+  it('should can parse values more than 1 million', () => {
+    const data = qif2json.parse(['!Type:Bank',
+      "D01/19'25",
+      'T0',
+      'CX',
+      'POpening Balance',
+      '^',
+      "D2 / 14' 5",
+      'T2,064,284.13',
+      'N',
+      'MTRANSF INTERNACIONAL RECIBIDA',
+    ].join('\r\n'), { dateFormat: "MM/D'YY" });
+
+    expect(data.type).toEqual('Bank');
+    expect(data.transactions[1].amount).toEqual(2064284.13);
+  });
 });


### PR DESCRIPTION
Currently any value greater than 999,999 is not working in the current library. I did this fix to interpret values ​​like:

```text
D12/30' 4
	T2,395,162.80
	N
	MTRANSF INTERNACIONAL RECIBIDA
	^
```